### PR TITLE
fix: bug with getenv(USER)

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -47,7 +47,7 @@ func (b *Bootstrap) bootstrap() {
 	// let InitConfig populate with overrides (if any)
 	_, err = utils.InitConfig()
 	if err != nil {
-		b.l.Fatal().Err(err).Msg("could not initiate generatedconfig")
+		b.l.Fatal().Err(err).Msg("could not initiate generated config")
 	}
 }
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -50,8 +50,13 @@ type SharedStorage struct {
 }
 
 func InitConfig() (*Config, error) {
+	var username string
 	// have to run cedana as root, but it overrides os.UserHomeDir w/ /root
-	username := os.Getenv("SUDO_USER")
+	username = os.Getenv("SUDO_USER")
+	if username == "" {
+		username = os.Getenv("USER")
+	}
+
 	u, err := user.Lookup(username)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
stupid bug introduced by trying to fix the issue where running cedana w/ sudo grabs the root user. we shouldn't even be using the homedir as a var anyway, but that's a fix for later